### PR TITLE
Make changes to quiz parser

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -229,7 +229,7 @@ The next question of the next flashcard will be displayed. Steps 1-2 are repeate
 Once the quiz stops, the score and answers will be displayed. Both information can be viewed when viewing the last attempt of the flashcard set.
 <p>&nbsp;</p>
 
-### **View last quiz attempt**: `view flset quiz`
+### **View last quiz attempt**: `quiz score flset`
 Shows the last attempt of a specific flashcard set.
 
 It comprises of the following information:
@@ -239,10 +239,10 @@ It comprises of the following information:
 
 <img src="images/view score.png" width="200px">
 
-Format: `view flset quiz:<setindex>`
+Format: `quiz score flset:<setindex>`
 
 Examples: 
-`view flset quiz:9`, `view flset quiz:16`
+`quiz score flset:9`, `quiz score flset:16`
 <p>&nbsp;</p>
 
 ### **Add a task**: `add task`
@@ -353,7 +353,7 @@ _{explain the feature here}_
 | -------------------------------- | --------------------------------------------------------------------------------------- |
 | **Quiz flset (without storage)** | `quiz flset:<setindex>` <br> e.g., `quiz flset:7`, `flip`, `c/w`, `cancel`              |
 | **Quiz flset (with storage)**    | `quiz flset store:<setindex>` <br> e.g., `quiz flset store:10`, `flip`, `c/w`, `cancel` |
-| **View flset**                   | `view flset quiz:<setindex>` <br>  e.g., `view flset quiz:6`                            |
+| **Quiz score flset**                   | `quiz score flset` <br>  e.g., `quiz score flset:6`                            |
 
 <p>&nbsp;</p>
 

--- a/src/main/java/seedu/address/logic/parser/parserutils/CommandTypeMatcher.java
+++ b/src/main/java/seedu/address/logic/parser/parserutils/CommandTypeMatcher.java
@@ -36,6 +36,11 @@ public class CommandTypeMatcher {
         throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
     }
 
+    private String getFirstWord(String userInput) {
+        String[] splittedWords = userInput.split(" ");
+        return splittedWords[0];
+    }
+
     private String getSecondWord(String userInput) {
         String[] splittedWords = userInput.split(" ");
         return splittedWords[1];
@@ -65,7 +70,8 @@ public class CommandTypeMatcher {
         case "w":
             return true;
         default:
-            return lowercaseCommand.contains("quiz");
+            return doesContainTwoOrMoreWords(lowercaseCommand) && (
+                    getFirstWord(lowercaseCommand).equals("quiz"));
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/quizparsers/QuizParser.java
+++ b/src/main/java/seedu/address/logic/parser/quizparsers/QuizParser.java
@@ -13,7 +13,8 @@ import seedu.address.model.Model;
 
 public class QuizParser implements Parser<Command> {
 
-    public static final String MESSAGE_PARSING_ERROR = "";
+    public static final String MESSAGE_PARSING_ERROR =
+            "The command for quiz is invalid. Please check the command format and try again.";
 
     @Override
     public Command<? super Model> parse(String userInput) throws ParseException {
@@ -21,8 +22,8 @@ public class QuizParser implements Parser<Command> {
             userInput = userInput.replace("quiz flset:", "");
             int index = parseNumber(userInput);
             return new StartCommand(index);
-        } else if (userInput.contains("view flset quiz:")) {
-            userInput = userInput.replace("view flset quiz:", "");
+        } else if (userInput.contains("quiz score flset:")) {
+            userInput = userInput.replace("quiz score flset:", "");
             int index = parseNumber(userInput);
             return new ViewScoreCommand(index);
         }


### PR DESCRIPTION
Problem: The checking of `contains("quiz")` is not specific enough for the `quiz` command. 

Quick fix: Changed to check for first word to be `"quiz"`. Also updated the parser and docs to standardize the `quiz` command with rest of `flashcard` commands.
