### PR TITLE
Search task with description and date keywords

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -284,7 +284,8 @@ Examples:
 
 ### **Search for a task**: `search task`
 
-Finds the tasks of which information contains any of the given keywords.  
+Finds the tasks of which information contains any of the given keywords (for `title`) 
+or all of the given keywords (`description` and `dateTime`).  
 
 Format: `search task <keyword>`
 

--- a/src/main/java/seedu/address/logic/commands/schedulecommands/ScheduleSearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/schedulecommands/ScheduleSearchCommand.java
@@ -6,7 +6,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.ScheduleModel;
-import seedu.address.model.task.TitleContainsKeywordsPredicate;
+import seedu.address.model.task.InfoContainsKeywordsPredicate;
 
 public class ScheduleSearchCommand extends Command<ScheduleModel> {
     public static final String COMMAND_WORD = "search task";
@@ -16,9 +16,9 @@ public class ScheduleSearchCommand extends Command<ScheduleModel> {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " CS2100";
 
-    private final TitleContainsKeywordsPredicate predicate;
+    private final InfoContainsKeywordsPredicate predicate;
 
-    public ScheduleSearchCommand(TitleContainsKeywordsPredicate predicate) {
+    public ScheduleSearchCommand(InfoContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/scheduleparsers/ScheduleSearchCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/scheduleparsers/ScheduleSearchCommandParser.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
 import seedu.address.logic.commands.schedulecommands.ScheduleSearchCommand;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.task.TitleContainsKeywordsPredicate;
+import seedu.address.model.task.InfoContainsKeywordsPredicate;
 
 public class ScheduleSearchCommandParser implements Parser<ScheduleSearchCommand> {
     /**
@@ -24,6 +24,6 @@ public class ScheduleSearchCommandParser implements Parser<ScheduleSearchCommand
 
         String[] titleKeywords = trimmedArgs.split("\\s+");
 
-        return new ScheduleSearchCommand(new TitleContainsKeywordsPredicate(Arrays.asList(titleKeywords)));
+        return new ScheduleSearchCommand(new InfoContainsKeywordsPredicate(Arrays.asList(titleKeywords)));
     }
 }

--- a/src/main/java/seedu/address/model/task/InfoContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/InfoContainsKeywordsPredicate.java
@@ -13,6 +13,10 @@ public class InfoContainsKeywordsPredicate implements Predicate<Task> {
         this.keywords = keywords;
     }
 
+    private boolean isEmptyKeyword(List<String> keyword) {
+        return keywords.size() == 0;
+    }
+
     private boolean doesTitleContainKeywords(Task task) {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getTitle().title, keyword));
@@ -20,22 +24,22 @@ public class InfoContainsKeywordsPredicate implements Predicate<Task> {
 
     private boolean doesDescriptionContainKeywords(Task task) {
         Optional<Description> description = task.getDescription();
-        return keywords.stream()
+        return !isEmptyKeyword(keywords) && keywords.stream()
                 .allMatch(keyword -> description.map(desc ->
                         StringUtil.containsWordIgnoreCase(desc.toString(), keyword)).orElse(false));
     }
 
     private boolean doesDateTimeContainKeywords(Task task) {
         Optional<DateTime> dateTime = task.getDateTime();
-        return keywords.stream()
+        return !isEmptyKeyword(keywords) && keywords.stream()
                 .allMatch(keyword -> dateTime.map(date ->
                         StringUtil.containsWordIgnoreCase(date.toString(), keyword)).orElse(false));
     }
 
     @Override
     public boolean test(Task task) {
-        return doesTitleContainKeywords(task) || doesDescriptionContainKeywords(task)
-                || doesDateTimeContainKeywords(task);
+        return doesDateTimeContainKeywords(task) || doesDescriptionContainKeywords(task) ||
+                doesTitleContainKeywords(task);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/InfoContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/InfoContainsKeywordsPredicate.java
@@ -6,10 +6,10 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
 
-public class TitleContainsKeywordsPredicate implements Predicate<Task> {
+public class InfoContainsKeywordsPredicate implements Predicate<Task> {
     private final List<String> keywords;
 
-    public TitleContainsKeywordsPredicate(List<String> keywords) {
+    public InfoContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
@@ -41,7 +41,7 @@ public class TitleContainsKeywordsPredicate implements Predicate<Task> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof TitleContainsKeywordsPredicate // instanceof handles nulls
-                && keywords.equals(((TitleContainsKeywordsPredicate) other).keywords)); // state check
+                || (other instanceof InfoContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((InfoContainsKeywordsPredicate) other).keywords)); // state check
     }
 }

--- a/src/main/java/seedu/address/model/task/InfoContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/InfoContainsKeywordsPredicate.java
@@ -13,7 +13,7 @@ public class InfoContainsKeywordsPredicate implements Predicate<Task> {
         this.keywords = keywords;
     }
 
-    private boolean isEmptyKeyword(List<String> keyword) {
+    private boolean isEmptyKeyword(List<String> keywords) {
         return keywords.size() == 0;
     }
 
@@ -38,8 +38,8 @@ public class InfoContainsKeywordsPredicate implements Predicate<Task> {
 
     @Override
     public boolean test(Task task) {
-        return doesDateTimeContainKeywords(task) || doesDescriptionContainKeywords(task) ||
-                doesTitleContainKeywords(task);
+        return doesDateTimeContainKeywords(task) || doesDescriptionContainKeywords(task)
+                || doesTitleContainKeywords(task);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/TitleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/TitleContainsKeywordsPredicate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.task;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
@@ -12,10 +13,29 @@ public class TitleContainsKeywordsPredicate implements Predicate<Task> {
         this.keywords = keywords;
     }
 
-    @Override
-    public boolean test(Task task) {
+    private boolean doesTitleContainKeywords(Task task) {
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(task.getTitle().title, keyword));
+    }
+
+    private boolean doesDescriptionContainKeywords(Task task) {
+        Optional<Description> description = task.getDescription();
+        return keywords.stream()
+                .allMatch(keyword -> description.map(desc ->
+                        StringUtil.containsWordIgnoreCase(desc.toString(), keyword)).orElse(false));
+    }
+
+    private boolean doesDateTimeContainKeywords(Task task) {
+        Optional<DateTime> dateTime = task.getDateTime();
+        return keywords.stream()
+                .allMatch(keyword -> dateTime.map(date ->
+                        StringUtil.containsWordIgnoreCase(date.toString(), keyword)).orElse(false));
+    }
+
+    @Override
+    public boolean test(Task task) {
+        return doesTitleContainKeywords(task) || doesDescriptionContainKeywords(task)
+                || doesDateTimeContainKeywords(task);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/commandtestutils/ScheduleCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/commandtestutils/ScheduleCommandTestUtil.java
@@ -17,8 +17,8 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.ScheduleModel;
 import seedu.address.model.systemlevelmodel.Schedule;
+import seedu.address.model.task.InfoContainsKeywordsPredicate;
 import seedu.address.model.task.Task;
-import seedu.address.model.task.TitleContainsKeywordsPredicate;
 
 public class ScheduleCommandTestUtil {
     public static final String VALID_TITLE_CS2103T = "CS2103T";
@@ -91,7 +91,7 @@ public class ScheduleCommandTestUtil {
 
         Task task = model.getFilteredTaskList().get(targetIndex.getZeroBased());
         final String[] splitName = task.getTitle().title.split("\\s+");
-        model.updateFilteredTaskList(new TitleContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredTaskList(new InfoContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredTaskList().size());
     }

--- a/src/test/java/seedu/address/logic/commands/schedulecommands/ScheduleSearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/schedulecommands/ScheduleSearchCommandTest.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_TASKS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.commandtestutils.ScheduleCommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.SampleTasks.CS2100_FINAL;
 import static seedu.address.testutil.SampleTasks.CS2100_TUTORIAL_HOMEWORK;
-import static seedu.address.testutil.SampleTasks.getSampleTasks;
+import static seedu.address.testutil.SampleTasks.getSampleSchedule;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -19,8 +19,8 @@ import seedu.address.model.ScheduleModelManager;
 import seedu.address.model.task.TitleContainsKeywordsPredicate;
 
 public class ScheduleSearchCommandTest {
-    private ScheduleModel model = new ScheduleModelManager(getTypicalSchedule());
-    private ScheduleModel expectedModel = new ScheduleModelManager(getTypicalSchedule());
+    private ScheduleModel model = new ScheduleModelManager(getSampleSchedule());
+    private ScheduleModel expectedModel = new ScheduleModelManager(getSampleSchedule());
 
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/schedulecommands/ScheduleSearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/schedulecommands/ScheduleSearchCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_TASKS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.commandtestutils.ScheduleCommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.SampleTasks.CS2100_FINAL;
 import static seedu.address.testutil.SampleTasks.CS2100_TUTORIAL_HOMEWORK;
+import static seedu.address.testutil.SampleTasks.ST2334_ASSIGNMENT;
 import static seedu.address.testutil.SampleTasks.getSampleSchedule;
 
 import java.util.Arrays;
@@ -16,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.model.ScheduleModel;
 import seedu.address.model.ScheduleModelManager;
-import seedu.address.model.task.TitleContainsKeywordsPredicate;
+import seedu.address.model.task.InfoContainsKeywordsPredicate;
 
 public class ScheduleSearchCommandTest {
     private ScheduleModel model = new ScheduleModelManager(getSampleSchedule());
@@ -25,10 +26,10 @@ public class ScheduleSearchCommandTest {
 
     @Test
     public void equals() {
-        TitleContainsKeywordsPredicate firstPredicate =
-                new TitleContainsKeywordsPredicate(Collections.singletonList("first"));
-        TitleContainsKeywordsPredicate secondPredicate =
-                new TitleContainsKeywordsPredicate(Collections.singletonList("second"));
+        InfoContainsKeywordsPredicate firstPredicate =
+                new InfoContainsKeywordsPredicate(Collections.singletonList("first"));
+        InfoContainsKeywordsPredicate secondPredicate =
+                new InfoContainsKeywordsPredicate(Collections.singletonList("second"));
 
         ScheduleSearchCommand findFirstCommand = new ScheduleSearchCommand(firstPredicate);
         ScheduleSearchCommand findSecondCommand = new ScheduleSearchCommand(secondPredicate);
@@ -53,7 +54,7 @@ public class ScheduleSearchCommandTest {
     @Test
     public void execute_zeroKeywords_noTaskFound() {
         String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 0);
-        TitleContainsKeywordsPredicate predicate = preparePredicate(" ");
+        InfoContainsKeywordsPredicate predicate = preparePredicate(" ");
         ScheduleSearchCommand command = new ScheduleSearchCommand(predicate);
         expectedModel.updateFilteredTaskList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -61,19 +62,59 @@ public class ScheduleSearchCommandTest {
     }
 
     @Test
-    public void execute_multipleKeywords_multipleTasksFound() {
+    public void execute_multipleTitleKeywords_multipleTasksFound() {
         String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 2);
-        TitleContainsKeywordsPredicate predicate = preparePredicate("CS2100");
+        InfoContainsKeywordsPredicate predicate = preparePredicate("CS2100");
         ScheduleSearchCommand command = new ScheduleSearchCommand(predicate);
         expectedModel.updateFilteredTaskList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CS2100_TUTORIAL_HOMEWORK, CS2100_FINAL), model.getFilteredTaskList());
     }
 
+    @Test
+    public void execute_multipleDescriptionKeywords_oneTaskFound() {
+        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 1);
+        InfoContainsKeywordsPredicate predicate = preparePredicate("Pipeline homework");
+        ScheduleSearchCommand command = new ScheduleSearchCommand(predicate);
+        expectedModel.updateFilteredTaskList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CS2100_TUTORIAL_HOMEWORK), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_multipleDescriptionKeywords_noTaskFound() {
+        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 0);
+        InfoContainsKeywordsPredicate predicate = preparePredicate("Pipeline Assignment");
+        ScheduleSearchCommand command = new ScheduleSearchCommand(predicate);
+        expectedModel.updateFilteredTaskList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_dateTimeKeywords_oneTaskFound() {
+        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 1);
+        InfoContainsKeywordsPredicate predicate = preparePredicate("2020-10-01 23:00");
+        ScheduleSearchCommand command = new ScheduleSearchCommand(predicate);
+        expectedModel.updateFilteredTaskList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ST2334_ASSIGNMENT), model.getFilteredTaskList());
+    }
+
+    @Test
+    public void execute_dateTimeKeywords_noTaskFound() {
+        String expectedMessage = String.format(MESSAGE_TASKS_LISTED_OVERVIEW, 0);
+        InfoContainsKeywordsPredicate predicate = preparePredicate("2020-10-01 1:00");
+        ScheduleSearchCommand command = new ScheduleSearchCommand(predicate);
+        expectedModel.updateFilteredTaskList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredTaskList());
+    }
+
     /**
      * Parses {@code userInput} into a {@code TitleContainsKeywordsPredicate}.
      */
-    private TitleContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new TitleContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private InfoContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new InfoContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/schedulecommands/ScheduleSearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/schedulecommands/ScheduleSearchCommandTest.java
@@ -5,9 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_TASKS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.commandtestutils.ScheduleCommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalTasks.CS2100_FINAL;
-import static seedu.address.testutil.TypicalTasks.CS2100_TUTORIAL_HOMEWORK;
-import static seedu.address.testutil.TypicalTasks.getTypicalSchedule;
+import static seedu.address.testutil.SampleTasks.CS2100_FINAL;
+import static seedu.address.testutil.SampleTasks.CS2100_TUTORIAL_HOMEWORK;
+import static seedu.address.testutil.SampleTasks.getSampleTasks;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/seedu/address/logic/parser/scheduleparsers/ScheduleSearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/scheduleparsers/ScheduleSearchCommandParserTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.schedulecommands.ScheduleSearchCommand;
-import seedu.address.model.task.TitleContainsKeywordsPredicate;
+import seedu.address.model.task.InfoContainsKeywordsPredicate;
 
 public class ScheduleSearchCommandParserTest {
 
@@ -25,7 +25,7 @@ public class ScheduleSearchCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         ScheduleSearchCommand expectedSearchCommand =
-                new ScheduleSearchCommand(new TitleContainsKeywordsPredicate(Arrays.asList("CS2101", "CS2103T")));
+                new ScheduleSearchCommand(new InfoContainsKeywordsPredicate(Arrays.asList("CS2101", "CS2103T")));
         assertParseSuccess(parser, "CS2101 CS2103T", expectedSearchCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/address/model/task/InfoContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/task/InfoContainsKeywordsPredicateTest.java
@@ -11,21 +11,21 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.TaskBuilder;
 
-public class TitleContainsKeywordsPredicateTest {
+public class InfoContainsKeywordsPredicateTest {
 
     @Test
     public void equals() {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        TitleContainsKeywordsPredicate firstPredicate = new TitleContainsKeywordsPredicate(firstPredicateKeywordList);
-        TitleContainsKeywordsPredicate secondPredicate = new TitleContainsKeywordsPredicate(secondPredicateKeywordList);
+        InfoContainsKeywordsPredicate firstPredicate = new InfoContainsKeywordsPredicate(firstPredicateKeywordList);
+        InfoContainsKeywordsPredicate secondPredicate = new InfoContainsKeywordsPredicate(secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        TitleContainsKeywordsPredicate firstPredicateCopy = new TitleContainsKeywordsPredicate(
+        InfoContainsKeywordsPredicate firstPredicateCopy = new InfoContainsKeywordsPredicate(
                 firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
@@ -42,31 +42,31 @@ public class TitleContainsKeywordsPredicateTest {
     @Test
     public void test_titleContainsKeywords_returnsTrue() {
         // One keyword
-        TitleContainsKeywordsPredicate predicate = new TitleContainsKeywordsPredicate(
+        InfoContainsKeywordsPredicate predicate = new InfoContainsKeywordsPredicate(
                 Collections.singletonList("CS2100"));
         assertTrue(predicate.test(new TaskBuilder().withTitle("CS2100").build()));
 
         // Multiple keywords
-        predicate = new TitleContainsKeywordsPredicate(Arrays.asList("CS2100", "Homework"));
+        predicate = new InfoContainsKeywordsPredicate(Arrays.asList("CS2100", "Homework"));
         assertTrue(predicate.test(new TaskBuilder().withTitle("CS2100 Homework").build()));
 
         // Only one matching keyword
-        predicate = new TitleContainsKeywordsPredicate(Arrays.asList("CS2103T", "Homework"));
+        predicate = new InfoContainsKeywordsPredicate(Arrays.asList("CS2103T", "Homework"));
         assertTrue(predicate.test(new TaskBuilder().withTitle("CS2100 Homework").build()));
 
         // Mixed-case keywords
-        predicate = new TitleContainsKeywordsPredicate(Arrays.asList("cS2103t", "qUiz"));
+        predicate = new InfoContainsKeywordsPredicate(Arrays.asList("cS2103t", "qUiz"));
         assertTrue(predicate.test(new TaskBuilder().withTitle("CS2103T Quiz").build()));
     }
 
     @Test
     public void test_titleDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
-        TitleContainsKeywordsPredicate predicate = new TitleContainsKeywordsPredicate(Collections.emptyList());
+        InfoContainsKeywordsPredicate predicate = new InfoContainsKeywordsPredicate(Collections.emptyList());
         assertFalse(predicate.test(new TaskBuilder().withTitle("CS2100").build()));
 
         // Non-matching keyword
-        predicate = new TitleContainsKeywordsPredicate(Arrays.asList("CS2103T"));
+        predicate = new InfoContainsKeywordsPredicate(Arrays.asList("CS2103T"));
         assertFalse(predicate.test(new TaskBuilder().withTitle("CS2100 Homework").build()));
     }
 }

--- a/src/test/java/seedu/address/model/task/InfoContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/task/InfoContainsKeywordsPredicateTest.java
@@ -69,4 +69,50 @@ public class InfoContainsKeywordsPredicateTest {
         predicate = new InfoContainsKeywordsPredicate(Arrays.asList("CS2103T"));
         assertFalse(predicate.test(new TaskBuilder().withTitle("CS2100 Homework").build()));
     }
+
+    @Test
+    public void test_descriptionContainsKeywords_returnsTrue() {
+        // One keyword
+        InfoContainsKeywordsPredicate predicate = new InfoContainsKeywordsPredicate(
+                Collections.singletonList("Pipeline"));
+        assertTrue(predicate.test(new TaskBuilder().withDescription("Pipeline tutorial HomeWork").build()));
+
+        // Multiple keywords
+        predicate = new InfoContainsKeywordsPredicate(Arrays.asList("CS2100", "Homework"));
+        assertTrue(predicate.test(new TaskBuilder().withDescription("CS2100 pipeline tutorial HomeWork").build()));
+
+        // Mixed-case keywords
+        predicate = new InfoContainsKeywordsPredicate(Arrays.asList("tuToriaL", "HomEWorK"));
+        assertTrue(predicate.test(new TaskBuilder().withDescription("Pipeline tutorial Homework").build()));
+    }
+
+    @Test
+    public void test_descriptionDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        InfoContainsKeywordsPredicate predicate = new InfoContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new TaskBuilder().withDescription("CS2100 Homework").build()));
+
+        // Non-matching keyword
+        predicate = new InfoContainsKeywordsPredicate(Arrays.asList("CS2103"));
+        assertFalse(predicate.test(new TaskBuilder().withDescription("CS2100 Homework").build()));
+    }
+
+    @Test
+    public void test_dateTimeContainsKeywords_returnsTrue() {
+        // Matching dateTime
+        InfoContainsKeywordsPredicate predicate = new InfoContainsKeywordsPredicate(
+                Arrays.asList("2020-10-10", "14:00"));
+        assertTrue(predicate.test(new TaskBuilder().withDateTime("2020-10-10 14:00").build()));
+    }
+
+    @Test
+    public void test_dateTimeDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        InfoContainsKeywordsPredicate predicate = new InfoContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(new TaskBuilder().withDateTime("2020-10-10 14:00").build()));
+
+        // Non-matching keyword
+        predicate = new InfoContainsKeywordsPredicate(Arrays.asList("2020-10-10", "12:00"));
+        assertFalse(predicate.test(new TaskBuilder().withDateTime("2020-10-10 14:00").build()));
+    }
 }


### PR DESCRIPTION
Add extensions to the search task functionality such that it can search for keywords appearing in the description or date time of each task.

I also rename the class `TitleContainsKeywordsPredicate` to `InfoContainsKeywordsPredicate` because now the predicate will search for `keywords` appearing in all `title`, `description` and `dateTime`.

**Note**: Unlike `title` where the search will return any task that contains any of the given keywords, search task for `description` and `dateTime` requires the task's description or dateTime to contain all of the given keywords. But if you guys want it to be the same as `title` then we can change it that way too.

I also add new tests for `ScheduleSearchCommand` and `InfoContainsKeywordsPredicate` and update the corresponding parts in UserGuide so that we don't have to mass update them at the final iteration.