### PR TITLE
Add quiz flset name

### DIFF
--- a/src/main/java/seedu/studybananas/logic/Logic.java
+++ b/src/main/java/seedu/studybananas/logic/Logic.java
@@ -12,6 +12,7 @@ import seedu.studybananas.logic.parser.exceptions.ParseException;
 import seedu.studybananas.model.Model;
 import seedu.studybananas.model.flashcard.Flashcard;
 import seedu.studybananas.model.flashcard.FlashcardSet;
+import seedu.studybananas.model.flashcard.FlashcardSetName;
 import seedu.studybananas.model.quiz.Quiz;
 import seedu.studybananas.model.systemlevelmodel.ReadOnlyFlashcardBank;
 import seedu.studybananas.model.systemlevelmodel.ReadOnlySchedule;
@@ -50,6 +51,12 @@ public interface Logic {
      * @param idx index of the flashcardSet.
      */
     FlashcardSet getFlashcardSetFromIndex(Index idx);
+
+    /**
+     * Get {@Code FlashcardSet} by {@Code FlashcardSetName}.
+     * @param flsetName name of the flashcardSet.
+     */
+    FlashcardSet getFlashcardSetFromName(FlashcardSetName flsetName);
 
 
     /**

--- a/src/main/java/seedu/studybananas/logic/LogicManager.java
+++ b/src/main/java/seedu/studybananas/logic/LogicManager.java
@@ -16,6 +16,7 @@ import seedu.studybananas.logic.parser.exceptions.ParseException;
 import seedu.studybananas.model.Model;
 import seedu.studybananas.model.flashcard.Flashcard;
 import seedu.studybananas.model.flashcard.FlashcardSet;
+import seedu.studybananas.model.flashcard.FlashcardSetName;
 import seedu.studybananas.model.quiz.Quiz;
 import seedu.studybananas.model.systemlevelmodel.ReadOnlyFlashcardBank;
 import seedu.studybananas.model.systemlevelmodel.ReadOnlySchedule;
@@ -84,6 +85,10 @@ public class LogicManager implements Logic {
         return model.getFlashcardSet(idx);
     }
 
+    @Override
+    public FlashcardSet getFlashcardSetFromName(FlashcardSetName name) {
+        return model.getFlashcardSet(name);
+    }
 
 
     @Override

--- a/src/main/java/seedu/studybananas/logic/commands/quizcommands/StartCommand.java
+++ b/src/main/java/seedu/studybananas/logic/commands/quizcommands/StartCommand.java
@@ -10,6 +10,7 @@ import seedu.studybananas.logic.commands.commandresults.QuizCommandResult;
 import seedu.studybananas.logic.commands.exceptions.CommandException;
 import seedu.studybananas.model.FlashcardQuizModel;
 import seedu.studybananas.model.flashcard.FlashcardSet;
+import seedu.studybananas.model.flashcard.FlashcardSetName;
 import seedu.studybananas.model.flashcard.Question;
 import seedu.studybananas.model.quiz.Quiz;
 import seedu.studybananas.ui.quizui.QuizCard;
@@ -22,17 +23,33 @@ public class StartCommand extends Command<FlashcardQuizModel> {
             + "To stop the current quiz, key 'cancel'.";
 
     public static final String MESSAGE_FLASHCARD_SET_NONEXISTENT =
-            "Flashcard set does not exist\nPlease provide a valid index";
+            "Flashcard set does not exist\nPlease provide a valid index or set name";
 
     public static final String MESSAGE_FLASHCARD_SET_EMPTY =
             "Flashcard set is empty\nPlease fill it with flashcards";
 
     private final int index;
+    private final FlashcardSetName flashcardSetName;
+    private FlashcardSet flashcardSet;
 
     private FlashcardQuizModel model;
 
+    /**
+     * Constructs a StartCommand based on the index provided.
+     * @param index of the flashcard set
+     */
     public StartCommand(int index) {
         this.index = index;
+        this.flashcardSetName = null;
+    }
+
+    /**
+     * Constructs a StartCommand based on the name provided.
+     * @param name of the flashcard set
+     */
+    public StartCommand(FlashcardSetName name) {
+        this.index = 0;
+        this.flashcardSetName = name;
     }
 
     @Override
@@ -46,8 +63,16 @@ public class StartCommand extends Command<FlashcardQuizModel> {
         }
 
         try {
-            Index indexWrapper = Index.fromOneBased(index);
-            FlashcardSet flashcardSet = model.getFlashcardSet(indexWrapper);
+            if (index == 0) {
+                flashcardSet = model.getFlashcardSet(flashcardSetName);
+            } else {
+                Index indexWrapper = Index.fromOneBased(index);
+                flashcardSet = model.getFlashcardSet(indexWrapper);
+            }
+
+            if (flashcardSet == null) {
+                throw new CommandException(MESSAGE_FLASHCARD_SET_NONEXISTENT);
+            }
 
             if (flashcardSet.getSize() == 0) { // check for empty flashcard set
                 throw new CommandException(MESSAGE_FLASHCARD_SET_EMPTY);
@@ -80,5 +105,12 @@ public class StartCommand extends Command<FlashcardQuizModel> {
      */
     public Index getQuizIndex() {
         return Index.fromOneBased(index);
+    }
+
+    /**
+     * Get the {@Code FlashcardSetName} of the flashcardSet for the quiz.
+     */
+    public FlashcardSetName getFlashcardSetName() {
+        return flashcardSetName;
     }
 }

--- a/src/main/java/seedu/studybananas/logic/commands/quizcommands/ViewScoreCommand.java
+++ b/src/main/java/seedu/studybananas/logic/commands/quizcommands/ViewScoreCommand.java
@@ -8,6 +8,7 @@ import seedu.studybananas.logic.commands.commandresults.CommandResult;
 import seedu.studybananas.logic.commands.commandresults.QuizCommandResult;
 import seedu.studybananas.logic.commands.exceptions.CommandException;
 import seedu.studybananas.model.FlashcardQuizModel;
+import seedu.studybananas.model.flashcard.FlashcardSet;
 import seedu.studybananas.model.flashcard.FlashcardSetName;
 
 public class ViewScoreCommand extends Command<FlashcardQuizModel> {
@@ -24,9 +25,24 @@ public class ViewScoreCommand extends Command<FlashcardQuizModel> {
                     + "since the last quiz. "
                     + "Do start a new quiz to update the score.";
     private final int index;
+    private final FlashcardSetName flashcardSetName;
 
+    /**
+     * Constructs a ViewScoreCommand based on the flashcard set index.
+     * @param index as provided
+     */
     public ViewScoreCommand(int index) {
         this.index = index;
+        this.flashcardSetName = null;
+    }
+
+    /**
+     * Constructs a ViewScoreCommand based on flashcard set name.
+     * @param flashcardSetName as specified
+     */
+    public ViewScoreCommand(FlashcardSetName flashcardSetName) {
+        this.index = 0;
+        this.flashcardSetName = flashcardSetName;
     }
 
     @Override
@@ -37,6 +53,27 @@ public class ViewScoreCommand extends Command<FlashcardQuizModel> {
         }
 
         try {
+            if (index == 0) { // case for getting flashcard set name directly
+
+                FlashcardSet flashcardSet = model.getFlashcardSet(flashcardSetName);
+
+                if (flashcardSet == null) {
+                    throw new CommandException(MESSAGE_QUIZ_NONEXISTENT);
+                }
+
+                model.setQuizRecordsToView(flashcardSetName);
+
+                String score = model.getQuizRecords(flashcardSetName);
+
+                if (score == null) {
+                    model.setQuizRecordsToView(null);
+                    throw new CommandException(MESSAGE_FLASHCARD_DELETED);
+                }
+
+                QuizCommandUtil.updateCommandResult(score);
+                return new QuizCommandResult(score, VIEW_SCORE);
+            }
+
             FlashcardSetName name = model.getFlashcardSet(Index.fromOneBased(index)).getFlashcardSetName();
 
             model.setQuizRecordsToView(name);

--- a/src/main/java/seedu/studybananas/logic/parser/quizparsers/QuizParser.java
+++ b/src/main/java/seedu/studybananas/logic/parser/quizparsers/QuizParser.java
@@ -29,8 +29,7 @@ public class QuizParser implements Parser<Command> {
             return parseStartCommand(lowerCaseUserInput);
         } else if (lowerCaseUserInput.startsWith(ViewScoreCommand.COMMAND_WORD)) {
             lowerCaseUserInput = lowerCaseUserInput.replace(ViewScoreCommand.COMMAND_WORD, EMPTY_SPACE);
-            int index = parseNumber(lowerCaseUserInput);
-            return new ViewScoreCommand(index);
+            return parseViewScoreCommand(lowerCaseUserInput);
         } else if (lowerCaseUserInput.startsWith(AnswerCommand.COMMAND_WORD)) {
             userInput = userInput.substring(AnswerCommand.STARTING_INDEX_OF_ANSWER);
             return new AnswerCommand(userInput);
@@ -67,12 +66,24 @@ public class QuizParser implements Parser<Command> {
     }
 
     private StartCommand parseStartCommand(String input) {
+        input = input.trim();
         try {
             int index = parseNumber(input);
             return new StartCommand(index);
         } catch (ParseException e) {
             FlashcardSetName name = new FlashcardSetName(input);
             return new StartCommand(name);
+        }
+    }
+
+    private ViewScoreCommand parseViewScoreCommand(String input) {
+        input = input.trim();
+        try {
+            int index = parseNumber(input);
+            return new ViewScoreCommand(index);
+        } catch (ParseException e) {
+            FlashcardSetName name = new FlashcardSetName(input);
+            return new ViewScoreCommand(name);
         }
     }
 }

--- a/src/main/java/seedu/studybananas/logic/parser/quizparsers/QuizParser.java
+++ b/src/main/java/seedu/studybananas/logic/parser/quizparsers/QuizParser.java
@@ -12,6 +12,7 @@ import seedu.studybananas.logic.commands.quizcommands.WrongCommand;
 import seedu.studybananas.logic.parser.Parser;
 import seedu.studybananas.logic.parser.exceptions.ParseException;
 import seedu.studybananas.model.Model;
+import seedu.studybananas.model.flashcard.FlashcardSetName;
 
 public class QuizParser implements Parser<Command> {
 
@@ -25,8 +26,7 @@ public class QuizParser implements Parser<Command> {
         lowerCaseUserInput = lowerCaseUserInput.trim();
         if (lowerCaseUserInput.startsWith(StartCommand.COMMAND_WORD)) {
             lowerCaseUserInput = lowerCaseUserInput.replace(StartCommand.COMMAND_WORD, EMPTY_SPACE);
-            int index = parseNumber(lowerCaseUserInput);
-            return new StartCommand(index);
+            return parseStartCommand(lowerCaseUserInput);
         } else if (lowerCaseUserInput.startsWith(ViewScoreCommand.COMMAND_WORD)) {
             lowerCaseUserInput = lowerCaseUserInput.replace(ViewScoreCommand.COMMAND_WORD, EMPTY_SPACE);
             int index = parseNumber(lowerCaseUserInput);
@@ -63,6 +63,16 @@ public class QuizParser implements Parser<Command> {
             return Integer.parseInt(input);
         } catch (NumberFormatException e) {
             throw new ParseException("Invalid characters provided for flashcard set number");
+        }
+    }
+
+    private StartCommand parseStartCommand(String input) {
+        try {
+            int index = parseNumber(input);
+            return new StartCommand(index);
+        } catch (ParseException e) {
+            FlashcardSetName name = new FlashcardSetName(input);
+            return new StartCommand(name);
         }
     }
 }

--- a/src/main/java/seedu/studybananas/model/FlashcardModel.java
+++ b/src/main/java/seedu/studybananas/model/FlashcardModel.java
@@ -6,6 +6,7 @@ import javafx.collections.ObservableList;
 import seedu.studybananas.commons.core.index.Index;
 import seedu.studybananas.model.flashcard.Flashcard;
 import seedu.studybananas.model.flashcard.FlashcardSet;
+import seedu.studybananas.model.flashcard.FlashcardSetName;
 import seedu.studybananas.model.systemlevelmodel.ReadOnlyFlashcardBank;
 
 public interface FlashcardModel {
@@ -75,6 +76,15 @@ public interface FlashcardModel {
      * @return the {@code FlashcardSet} in the high-level {@code FlashcardBank} with that {@code Index}
      */
     FlashcardSet getFlashcardSet(Index index);
+
+    /**
+     * Retrieves the {@code FlashcardSet} with the given {@code FlashcardSetName}.
+     * Used for {@code Quiz}.
+     *
+     * @param flsetName the reference {@code FlashcardSetName}
+     * @return the {@code FlashcardSet} in the high-level {@code FlashcardBank} with that {@code FlashcardSetName}
+     */
+    FlashcardSet getFlashcardSet(FlashcardSetName flsetName);
 
     /**
      * Replaces the target {@code FlashcardSet} in the {@code FlashcardBank}

--- a/src/main/java/seedu/studybananas/model/FlashcardModelManager.java
+++ b/src/main/java/seedu/studybananas/model/FlashcardModelManager.java
@@ -10,6 +10,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.studybananas.commons.core.index.Index;
 import seedu.studybananas.model.flashcard.Flashcard;
 import seedu.studybananas.model.flashcard.FlashcardSet;
+import seedu.studybananas.model.flashcard.FlashcardSetName;
 import seedu.studybananas.model.systemlevelmodel.FlashcardBank;
 import seedu.studybananas.model.systemlevelmodel.ReadOnlyFlashcardBank;
 
@@ -60,6 +61,16 @@ public class FlashcardModelManager implements FlashcardModel {
     @Override
     public FlashcardSet getFlashcardSet(Index index) {
         return filteredFlashcardSets.get(index.getZeroBased());
+    }
+
+    @Override
+    public FlashcardSet getFlashcardSet(FlashcardSetName flsetName) {
+        for (FlashcardSet flset : filteredFlashcardSets) {
+            if (flset.getName().equals(flsetName)) {
+                return flset;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/seedu/studybananas/model/FlashcardQuizModelManager.java
+++ b/src/main/java/seedu/studybananas/model/FlashcardQuizModelManager.java
@@ -60,6 +60,11 @@ public class FlashcardQuizModelManager implements FlashcardQuizModel {
     }
 
     @Override
+    public FlashcardSet getFlashcardSet(FlashcardSetName name) {
+        return flashcardModelManager.getFlashcardSet(name);
+    }
+
+    @Override
     public void setFlashcardSet(FlashcardSet target, FlashcardSet editedFlashcardSet) {
         flashcardModelManager.setFlashcardSet(target, editedFlashcardSet);
     }

--- a/src/main/java/seedu/studybananas/model/ModelManager.java
+++ b/src/main/java/seedu/studybananas/model/ModelManager.java
@@ -258,6 +258,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public FlashcardSet getFlashcardSet(FlashcardSetName flsetName) {
+        return flashcardQuizModelManager.getFlashcardSet(flsetName);
+    }
+
+    @Override
     public boolean hasFlashcardSet(FlashcardSet flashcardSet) {
         return flashcardQuizModelManager.hasFlashcardSet(flashcardSet);
     }

--- a/src/main/java/seedu/studybananas/model/flashcard/Answer.java
+++ b/src/main/java/seedu/studybananas/model/flashcard/Answer.java
@@ -41,12 +41,12 @@ public class Answer {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || other instanceof seedu.studybananas.model.flashcard.Answer // instanceof handles nulls
-                && answer.equals(((seedu.studybananas.model.flashcard.Answer) other).answer); // state check
+                || other instanceof Answer // instanceof handles nulls
+                && answer.toLowerCase().equals(((Answer) other).answer.toLowerCase()); // state check
     }
 
     @Override
     public int hashCode() {
-        return answer.hashCode();
+        return answer.toLowerCase().hashCode();
     }
 }

--- a/src/main/java/seedu/studybananas/model/flashcard/FlashcardSetName.java
+++ b/src/main/java/seedu/studybananas/model/flashcard/FlashcardSetName.java
@@ -48,12 +48,13 @@ public class FlashcardSetName {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || other instanceof FlashcardSetName // instanceof handles nulls
-                && name.toLowerCase().equals(((FlashcardSetName) other).name.toLowerCase()); // state check
+                && name.toLowerCase().equals((
+                        (FlashcardSetName) other).name.toLowerCase()); // state check
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return name.toLowerCase().hashCode();
     }
 
 }

--- a/src/main/java/seedu/studybananas/model/flashcard/FlashcardSetName.java
+++ b/src/main/java/seedu/studybananas/model/flashcard/FlashcardSetName.java
@@ -48,7 +48,7 @@ public class FlashcardSetName {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || other instanceof FlashcardSetName // instanceof handles nulls
-                && name.equals(((FlashcardSetName) other).name); // state check
+                && name.toLowerCase().equals(((FlashcardSetName) other).name.toLowerCase()); // state check
     }
 
     @Override

--- a/src/main/java/seedu/studybananas/model/flashcard/Question.java
+++ b/src/main/java/seedu/studybananas/model/flashcard/Question.java
@@ -41,13 +41,14 @@ public class Question {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || other instanceof seedu.studybananas.model.flashcard.Question // instanceof handles nulls
-                && question.equals(((seedu.studybananas.model.flashcard.Question) other).question); // state check
+                || other instanceof Question // instanceof handles nulls
+                && question.toLowerCase().equals((
+                        (Question) other).question.toLowerCase()); // state check
     }
 
     @Override
     public int hashCode() {
-        return question.hashCode();
+        return question.toLowerCase().hashCode();
     }
 }
 

--- a/src/main/java/seedu/studybananas/ui/util/ScheduleUiUtil.java
+++ b/src/main/java/seedu/studybananas/ui/util/ScheduleUiUtil.java
@@ -99,7 +99,7 @@ public class ScheduleUiUtil {
     /**
      * Constructs quiz description from description and {@Code Logic}.
      * @throws ParseException if the description is not valid command.
-     * @throws IndexOutOfBoundsException if the flashcardSet index is not valid;
+     * @throws IndexOutOfBoundsException if the flashcardSet index or name is not valid;
      */
     public static QuizDescription constructQuizDescription(String description, Logic logic)
             throws ParseException, IndexOutOfBoundsException {
@@ -109,10 +109,21 @@ public class ScheduleUiUtil {
         }
 
         StartCommand quizStartCommand = (StartCommand) command;
-        FlashcardSet flashcardSet = logic.getFlashcardSetFromIndex(quizStartCommand.getQuizIndex());
-        String text = "Quiz: " + flashcardSet.getFlashcardSetName();
-        return new QuizDescription(text, quizStartCommand, logic);
+        try {
+            FlashcardSet flashcardSet = logic.getFlashcardSetFromIndex(quizStartCommand.getQuizIndex());
+            String text = "Quiz: " + flashcardSet.getFlashcardSetName();
+            return new QuizDescription(text, quizStartCommand, logic);
 
+        } catch (IndexOutOfBoundsException e) { // handles case where quiz is stored by name
+            FlashcardSet flashcardSet = logic.getFlashcardSetFromName(quizStartCommand.getFlashcardSetName());
+
+            if (flashcardSet == null) { // if flashcard set name is invalid
+                throw new IndexOutOfBoundsException("Flashcard set is non-existent.");
+            }
+
+            String text = "Quiz: " + flashcardSet.getFlashcardSetName();
+            return new QuizDescription(text, quizStartCommand, logic);
+        }
     }
 
     /**

--- a/src/test/java/seedu/studybananas/logic/commands/flashcardcommands/AddFlashcardCommandTest.java
+++ b/src/test/java/seedu/studybananas/logic/commands/flashcardcommands/AddFlashcardCommandTest.java
@@ -21,6 +21,7 @@ import seedu.studybananas.logic.commands.exceptions.CommandException;
 import seedu.studybananas.model.FlashcardModel;
 import seedu.studybananas.model.flashcard.Flashcard;
 import seedu.studybananas.model.flashcard.FlashcardSet;
+import seedu.studybananas.model.flashcard.FlashcardSetName;
 import seedu.studybananas.model.systemlevelmodel.FlashcardBank;
 import seedu.studybananas.model.systemlevelmodel.ReadOnlyFlashcardBank;
 import seedu.studybananas.testutil.FlashcardBuilder;
@@ -208,6 +209,11 @@ public class AddFlashcardCommandTest {
 
         @Override
         public FlashcardSet getFlashcardSet(Index index) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public FlashcardSet getFlashcardSet(FlashcardSetName flsetName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/studybananas/logic/commands/flashcardcommands/AddFlashcardSetCommandTest.java
+++ b/src/test/java/seedu/studybananas/logic/commands/flashcardcommands/AddFlashcardSetCommandTest.java
@@ -22,6 +22,7 @@ import seedu.studybananas.logic.commands.exceptions.CommandException;
 import seedu.studybananas.model.FlashcardModel;
 import seedu.studybananas.model.flashcard.Flashcard;
 import seedu.studybananas.model.flashcard.FlashcardSet;
+import seedu.studybananas.model.flashcard.FlashcardSetName;
 import seedu.studybananas.model.systemlevelmodel.ReadOnlyFlashcardBank;
 import seedu.studybananas.testutil.FlashcardSetBuilder;
 
@@ -155,6 +156,11 @@ public class AddFlashcardSetCommandTest {
 
         @Override
         public FlashcardSet getFlashcardSet(Index index) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public FlashcardSet getFlashcardSet(FlashcardSetName flsetName) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/studybananas/logic/commands/quizcommands/StartCommandTest.java
+++ b/src/test/java/seedu/studybananas/logic/commands/quizcommands/StartCommandTest.java
@@ -17,6 +17,7 @@ import seedu.studybananas.logic.commands.exceptions.CommandException;
 import seedu.studybananas.model.FlashcardQuizModel;
 import seedu.studybananas.model.FlashcardQuizModelManager;
 import seedu.studybananas.model.flashcard.FlashcardSet;
+import seedu.studybananas.model.flashcard.FlashcardSetName;
 import seedu.studybananas.model.systemlevelmodel.FlashcardBank;
 import seedu.studybananas.model.systemlevelmodel.QuizRecords;
 import seedu.studybananas.testutil.FlashcardSetBuilder;
@@ -26,14 +27,19 @@ public class StartCommandTest {
 
     private static final int VALID_INDEX = 1;
     private static final int INVALID_INDEX = 10;
+    private static final FlashcardSetName VALID_NAME = new FlashcardSetName("physics");
+    private static final FlashcardSetName INVALID_NAME = new FlashcardSetName("Weird name");
+
 
     private final StartCommand startCommand = new StartCommand(VALID_INDEX);
+    private final StartCommand startCommandWithName = new StartCommand(VALID_NAME);
     private final FlashcardQuizModel model = new
             FlashcardQuizModelManager(getTypicalFlashcardBank(), new QuizRecords());
 
     @Test
     public void execute_nullModel_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> startCommand.execute(null));
+        assertThrows(NullPointerException.class, () -> startCommandWithName.execute(null));
     }
 
     @Test
@@ -41,6 +47,8 @@ public class StartCommandTest {
         model.start(new QuizBuilder().buildDefaultQuiz());
         assertThrows(CommandException.class,
                 MESSAGE_QUIZ_IN_PROGRESS, () -> startCommand.execute(model));
+        assertThrows(CommandException.class,
+                MESSAGE_QUIZ_IN_PROGRESS, () -> startCommandWithName.execute(model));
     }
 
     @Test
@@ -48,6 +56,10 @@ public class StartCommandTest {
         StartCommand invalidIndexStartCommand = new StartCommand(INVALID_INDEX);
         assertThrows(CommandException.class,
                 MESSAGE_FLASHCARD_SET_NONEXISTENT, () -> invalidIndexStartCommand.execute(model));
+
+        StartCommand invalidNameStartCommand = new StartCommand(INVALID_NAME);
+        assertThrows(CommandException.class,
+                MESSAGE_FLASHCARD_SET_NONEXISTENT, () -> invalidNameStartCommand.execute(model));
     }
 
     @Test
@@ -61,6 +73,8 @@ public class StartCommandTest {
         FlashcardQuizModel model = new FlashcardQuizModelManager(flashcardBank, new QuizRecords());
         assertThrows(CommandException.class,
                 MESSAGE_FLASHCARD_SET_EMPTY, () -> startCommand.execute(model));
+        assertThrows(CommandException.class,
+                MESSAGE_FLASHCARD_SET_EMPTY, () -> startCommandWithName.execute(model));
     }
 
     @Test
@@ -70,5 +84,14 @@ public class StartCommandTest {
                 new FlashcardQuizModelManager(getTypicalFlashcardBank(), new QuizRecords());
 
         assertCommandSuccess(startCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_modelStartQuizWithName_success() {
+        String expectedMessage = MESSAGE_AVAIL_ON_QUESTION;
+        FlashcardQuizModel expectedModel =
+                new FlashcardQuizModelManager(getTypicalFlashcardBank(), new QuizRecords());
+
+        assertCommandSuccess(startCommandWithName, model, expectedMessage, expectedModel);
     }
 }

--- a/src/test/java/seedu/studybananas/logic/commands/quizcommands/ViewScoreCommandTest.java
+++ b/src/test/java/seedu/studybananas/logic/commands/quizcommands/ViewScoreCommandTest.java
@@ -18,14 +18,18 @@ import seedu.studybananas.testutil.QuizBuilder;
 public class ViewScoreCommandTest {
     private static final int VALID_INDEX = 1;
     private static final int INVALID_INDEX = 10;
+    private static final FlashcardSetName VALID_NAME = new FlashcardSetName("Physics");
+    private static final FlashcardSetName INVALID_NAME = new FlashcardSetName("Weird name");
 
     private final ViewScoreCommand viewScoreCommand = new ViewScoreCommand(VALID_INDEX);
+    private final ViewScoreCommand viewScoreCommandWithName = new ViewScoreCommand(VALID_NAME);
     private final FlashcardQuizModel model = new
             FlashcardQuizModelManager(getTypicalFlashcardBank(), getTypicalQuizRecords());
 
     @Test
     public void execute_nullModel_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> viewScoreCommand.execute(null));
+        assertThrows(NullPointerException.class, () -> viewScoreCommandWithName.execute(null));
     }
 
     @Test
@@ -33,13 +37,19 @@ public class ViewScoreCommandTest {
         model.start(new QuizBuilder().buildDefaultQuiz());
         assertThrows(CommandException.class,
                 MESSAGE_UNABLE_TO_VIEW, () -> viewScoreCommand.execute(model));
+        assertThrows(CommandException.class,
+                MESSAGE_UNABLE_TO_VIEW, () -> viewScoreCommandWithName.execute(model));
     }
 
     @Test
     public void execute_modelFlashcardSetIndexOutOfBounds_throwsCommandException() {
-        ViewScoreCommand invalidIndexStartCommand = new ViewScoreCommand(INVALID_INDEX);
+        ViewScoreCommand invalidIndexScoreCommand = new ViewScoreCommand(INVALID_INDEX);
         assertThrows(CommandException.class,
-                MESSAGE_QUIZ_NONEXISTENT, () -> invalidIndexStartCommand.execute(model));
+                MESSAGE_QUIZ_NONEXISTENT, () -> invalidIndexScoreCommand.execute(model));
+
+        ViewScoreCommand invalidNameScoreCommand = new ViewScoreCommand(INVALID_NAME);
+        assertThrows(CommandException.class,
+                MESSAGE_QUIZ_NONEXISTENT, () -> invalidNameScoreCommand.execute(model));
     }
 
     @Test
@@ -50,5 +60,12 @@ public class ViewScoreCommandTest {
                 new FlashcardQuizModelManager(getTypicalFlashcardBank(), getTypicalQuizRecords());
 
         assertCommandSuccess(viewScoreCommand, model, expectedMessage, expectedModel);
+
+        expectedMessage = model.getQuizRecords(
+                new FlashcardSetName("physics"));
+        expectedModel =
+                new FlashcardQuizModelManager(getTypicalFlashcardBank(), getTypicalQuizRecords());
+
+        assertCommandSuccess(viewScoreCommandWithName, model, expectedMessage, expectedModel);
     }
 }

--- a/src/test/java/seedu/studybananas/logic/parser/quizparsers/QuizParserTest.java
+++ b/src/test/java/seedu/studybananas/logic/parser/quizparsers/QuizParserTest.java
@@ -15,6 +15,7 @@ import seedu.studybananas.logic.commands.quizcommands.StartCommand;
 import seedu.studybananas.logic.commands.quizcommands.ViewScoreCommand;
 import seedu.studybananas.logic.commands.quizcommands.WrongCommand;
 import seedu.studybananas.logic.parser.exceptions.ParseException;
+import seedu.studybananas.model.flashcard.FlashcardSetName;
 
 public class QuizParserTest {
 
@@ -54,12 +55,20 @@ public class QuizParserTest {
         StartCommand expectedCommand = new StartCommand(1);
         StartCommand startCommand = (StartCommand) parser.parse("quiz flset:1");
         assertEquals(expectedCommand, startCommand);
+
+        expectedCommand = new StartCommand(new FlashcardSetName("physics"));
+        startCommand = (StartCommand) parser.parse("quiz flset: physics");
+        assertEquals(expectedCommand, startCommand);
     }
 
     @Test
     public void parse_viewScoreCommand_returnsViewScoreCommand() throws ParseException {
         ViewScoreCommand expectedCommand = new ViewScoreCommand(1);
         ViewScoreCommand viewScoreCommand = (ViewScoreCommand) parser.parse("quiz score flset:1");
+        assertEquals(expectedCommand, viewScoreCommand);
+
+        expectedCommand = new ViewScoreCommand(new FlashcardSetName("economics"));
+        viewScoreCommand = (ViewScoreCommand) parser.parse("quiz score flset:   ecOnoMics");
         assertEquals(expectedCommand, viewScoreCommand);
     }
 


### PR DESCRIPTION
We can now start a quiz/view a score using a flashcard set name. Same for the start quiz command description in task. The original index one still works too.

Flashcards are now non-case-sensitive, meaning cannot add duplicate flashcards if the question, answer or set name is the same but with different cases. this implementation helps the one for the quiz too, such that:
`quiz flset: Physics` and `quiz flset:       pHySiCs` has the same result. Same for view score.

closes #172 